### PR TITLE
Load activesupport core extensions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ begin
     gem.add_development_dependency "rspec", ">= 2.0.0"
     gem.add_dependency "httparty"
     gem.add_dependency "xml-simple"
-    gem.add_dependency "activesupport"
+    gem.add_dependency "activesupport", ">= 3.0.0"
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
   end
   Jeweler::GemcutterTasks.new

--- a/lib/lastfm.rb
+++ b/lib/lastfm.rb
@@ -8,7 +8,7 @@ require 'lastfm/method_category/artist'
 require 'rubygems'
 require 'digest/md5'
 require 'httparty'
-require 'active_support'
+require 'active_support/all'
 
 class Lastfm
   API_ROOT = 'http://ws.audioscrobbler.com/2.0'


### PR DESCRIPTION
I just noticed the bump to active_support 3 also requires that the core extensions are loaded, otherwise the 'camelize' method can't be found.
