### PR TITLE
Lastfm::ApiError.code support

### DIFF
--- a/lib/lastfm.rb
+++ b/lib/lastfm.rb
@@ -23,7 +23,13 @@ class Lastfm
   attr_accessor :session
 
   class Error < StandardError; end
-  class ApiError < Error; end
+  class ApiError < Error
+    attr_accessor :code
+    def initialize(message, code = nil)
+      super(message)
+      @code = code
+    end
+  end
 
   def initialize(api_key, api_secret)
     @api_key = api_key
@@ -76,7 +82,7 @@ class Lastfm
 
     response = Response.new(self.class.send(http_method, '/', (http_method == :post ? :body : :query) => params).body)
     unless response.success?
-      raise ApiError.new(response.message)
+      raise ApiError.new(response.message, response.error)
     end
 
     response

--- a/spec/lastfm_spec.rb
+++ b/spec/lastfm_spec.rb
@@ -107,7 +107,9 @@ XML
 
       lambda {
         @lastfm.request('xxx.yyy', { :foo => 'bar' }, :post)
-      }.should raise_error(Lastfm::ApiError, 'Invalid API key - You must be granted a valid key by last.fm')
+      }.should raise_error(Lastfm::ApiError, 'Invalid API key - You must be granted a valid key by last.fm') {|error|
+        error.code.should == 10
+      }
     end
   end
 


### PR DESCRIPTION
Added support for `Lastfm::ApiError.code` so I could identify error 9: http://www.last.fm/api/scrobbling

For a full list see http://www.last.fm/api/errorcodes
