### PR TITLE
accept hash parameter so that it takes additional parameters as well

### DIFF
--- a/lib/lastfm/util.rb
+++ b/lib/lastfm/util.rb
@@ -7,17 +7,25 @@ class Lastfm
     def self.build_options(args, mandatory, optional)
       options = {}
 
-      mandatory.each_with_index do |name, index|
-        raise ArgumentError.new('%s is required' % name) unless args[index]
-        options[name] = args[index]
-      end
-
-      optional.each_with_index do |name, index|
-        value = name[1]
-        if value.kind_of?(Proc)
-          value = value.call
+      if args.first.is_a?(Hash)
+        # mandatory parameter check
+        mandatory.each do |name|
+          raise ArgumentError.new("#{name} is required") unless args.first.has_key?(name)
         end
-        options[name[0]] = args[index + mandatory.size] || value
+        options = args.first
+      else
+        mandatory.each_with_index do |name, index|
+          raise ArgumentError.new('%s is required' % name) unless args[index]
+          options[name] = args[index]
+        end
+
+        optional.each_with_index do |name, index|
+          value = name[1]
+          if value.kind_of?(Proc)
+            value = value.call
+          end
+          options[name[0]] = args[index + mandatory.size] || value
+        end
       end
 
       options


### PR DESCRIPTION
Hi again. I made a change so that any method accepts a hash parameter instead of args array. I did this because I needed to pass additional parameters such as "lang" that wasn't supported by any methods, which is a headache that I might need to add the optional parameter to all methods.

This change doesn't break anything since I just wrote IF condition for when the first parameter is hash, or not. Users of this library still can use the same way like:

artist = lastfm.artist.get_info @artist.name

but also:

artist = lastfm.artist.get_info :artist => @artist.name, :lang => "jp"

I haven't written any test case because I am not sure if you like this change. I may keep using this lib from my repo if this pull request is not acceptable. If you like this change, I am happy to write test case for this. let me know. Cheers
