### PR TITLE
Use session authentication for getRecentTracks

### DIFF
--- a/lib/lastfm/method_category/user.rb
+++ b/lib/lastfm/method_category/user.rb
@@ -33,7 +33,7 @@ class Lastfm
         Lastfm::Util::force_array(result)
       end
 
-      regular_method :get_recent_tracks, [:user], [[:limit, nil], [:page, nil], [:to, nil], [:from, nil]] do |response|
+      method_with_authentication :get_recent_tracks, [:user], [[:limit, nil], [:page, nil], [:to, nil], [:from, nil]] do |response|
         response.xml['recenttracks']['track']
       end
 

--- a/spec/method_specs/user_spec.rb
+++ b/spec/method_specs/user_spec.rb
@@ -205,7 +205,7 @@ describe '#user' do
         :limit => nil,
         :to => nil,
         :from => nil
-      }).and_return(make_response('user_get_recent_tracks'))
+      }, :get, true, true).and_return(make_response('user_get_recent_tracks'))
       tracks = @lastfm.user.get_recent_tracks(:user => 'test')
       tracks[1]['artist']['content'].should == 'Kylie Minogue'
       tracks.size.should == 2
@@ -218,7 +218,7 @@ describe '#user' do
         :limit => nil,
         :to => nil,
         :from => nil
-      }).and_return(make_response('user_get_recent_tracks_malformed'))
+      }, :get, true, true).and_return(make_response('user_get_recent_tracks_malformed'))
       tracks = @lastfm.user.get_recent_tracks(:user => 'test')
     end
   end


### PR DESCRIPTION
This changes the method generator from `regular_method` to `method_with_authentication` for `user.get_recent_tracks` and updates the test expectations accordingly.

Some users including myself have recent tracks set to private, for which authentication is needed. All other requests work the same as before.