### PR TITLE
Optional params on artist#get_info

### DIFF
--- a/lib/lastfm/method_category/artist.rb
+++ b/lib/lastfm/method_category/artist.rb
@@ -17,7 +17,7 @@ class Lastfm
 
       regular_method(
         :get_info,
-        :required => [:artist]
+        :required => any_params(:artist, :mbid)
       ) do |response|
         response.xml['artist']
       end


### PR DESCRIPTION
According to the lastfm API

**artist.getInfo:**
- artist (Required (unless mbid) : The artist name
- mbid (Optional) : The musicbrainz id for the artist
  ...

I followed your new implementation described in #37, 
