### PR TITLE
altering artist.get_top_tags to match API call documentation

### DIFF
--- a/lib/lastfm/method_category/artist.rb
+++ b/lib/lastfm/method_category/artist.rb
@@ -63,9 +63,8 @@ class Lastfm
 
       regular_method(
         :get_top_tags,
-        :required => [:artist],
+        :required => any_params([:artist], [:mbid]),
         :optional => [
-          [:mbid, nil],
           [:autocorrect, nil]
         ]
       ) do |response|


### PR DESCRIPTION
The documentation isn't written the best way, but it's either artist or mbid, you don't need both.
Check it at http://www.last.fm/api/show/artist.getTopTags.
