### PR TITLE
changed encoding to fix XML parsing issues

### DIFF
--- a/lib/lastfm/response.rb
+++ b/lib/lastfm/response.rb
@@ -8,7 +8,7 @@ class Lastfm
     def initialize(body)
       @xml = XmlSimple.xml_in(body, 'ForceArray' => ['image', 'tag', 'user', 'event', 'correction'])
     rescue REXML::ParseException
-      @xml = XmlSimple.xml_in(body.encode(Encoding.find("ISO-8859-1"), :undef => :replace), 'ForceArray' => ['image', 'tag', 'user', 'event', 'correction'])
+      @xml = XmlSimple.xml_in(body.encode(Encoding.find("UTF-8"), :undef => :replace), 'ForceArray' => ['image', 'tag', 'user', 'event', 'correction'])
     end
 
     def success?


### PR DESCRIPTION
ISO encoding led to XML parsing issues for artists with non english character names (e.g Jhené Aiko). Switching encoding to UTF is an easy fix. 
