### PR TITLE
Use session authentication for getRecentTracks (updated)

### DIFF
--- a/lib/lastfm/method_category/user.rb
+++ b/lib/lastfm/method_category/user.rb
@@ -82,7 +82,7 @@ class Lastfm
         Lastfm::Util::force_array(result)
       end
 
-      regular_method(
+      method_with_authentication(
         :get_recent_tracks,
         :required => [:user],
         :optional => [

--- a/spec/method_specs/user_spec.rb
+++ b/spec/method_specs/user_spec.rb
@@ -227,7 +227,7 @@ describe '#user' do
         :limit => nil,
         :to => nil,
         :from => nil
-      }).and_return(make_response('user_get_recent_tracks'))
+      }, :get, true, true).and_return(make_response('user_get_recent_tracks'))
       tracks = @lastfm.user.get_recent_tracks(:user => 'test')
       tracks[1]['artist']['content'].should == 'Kylie Minogue'
       tracks.size.should == 2
@@ -240,8 +240,8 @@ describe '#user' do
         :limit => nil,
         :to => nil,
         :from => nil
-      }).and_return(make_response('user_get_recent_tracks_malformed'))
-      tracks = @lastfm.user.get_recent_tracks(:user => 'test')
+      }, :get, true, true).and_return(make_response('user_get_recent_tracks_malformed'))
+      @lastfm.user.get_recent_tracks(:user => 'test')
     end
   end
 


### PR DESCRIPTION
This is #44 updated for the actual code (#44 can’t be merged since the code has changed since it was submitted).

> This changes the method generator from `regular_method` to `method_with_authentication` for user.get_recent_tracks and updates the test expectations accordingly.
>
> Some users including myself have recent tracks set to private, for which authentication is needed. All other requests work the same as before.