### PR TITLE
[#27] check for nil releasedate

### DIFF
--- a/lib/lastfm/method_category/album.rb
+++ b/lib/lastfm/method_category/album.rb
@@ -30,7 +30,7 @@ class Lastfm
       ) do |response|
         result = response.xml['album']
 
-        result['releasedate'].lstrip! unless result['releasedate'].empty?
+        result['releasedate'].lstrip! unless result['releasedate'].nil? or result['releasedate'].empty?
         result
       end
 


### PR DESCRIPTION
```ruby
      args = {
        artist: "Fleetwood Mac",
        album: "The Very Best of Fleetwood Mac"
      }
      Heros::Music::Clients.lastfm.album.get_info(artist: args[:artist], album: args[:album])
```

errors with

```
NoMethodError: undefined method `empty?' for nil:NilClass
/var/lib/gems/2.1.0/gems/lastfm-1.27.0/lib/lastfm/method_category/album.rb:36:in `block in <class:Album>'
/var/lib/gems/2.1.0/gems/lastfm-1.27.0/lib/lastfm/method_category/base.rb:45:in `call'
/var/lib/gems/2.1.0/gems/lastfm-1.27.0/lib/lastfm/method_category/base.rb:45:in `block in __define_method'
```

because sometimes lastfm does not send `releasedate` in `album` object.